### PR TITLE
Respect input type number in on-change helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@ pom.xml.asc
 .lein-failures
 .nrepl-port
 .cpcache/
-./shadow-cljs/
-./cljs/
+.shadow-cljs/
+.cljs/
 *.iml
 .idea/
 /public/js/compiled/

--- a/src/formulario/helper.cljs
+++ b/src/formulario/helper.cljs
@@ -43,11 +43,15 @@
   "Syntactic sugar function for the form inputs.
   The output should be used as the value for the on-change event listener of the inputs."
   ([id path]
-    (on-change id path nil))
+   (on-change id path nil))
   ([id path form-value-atom]
    (fn [e]
-     (let [value (-> e (.-target) (.-value))]
-       (when form-value-atom (swap! form-value-atom assoc-in path value))
+     (let [target (.-target e)
+           value (.-value target)
+           value* (case (.-type target)
+                    "number" (js/Number value)
+                    value)]
+       (when form-value-atom (swap! form-value-atom assoc-in path value*))
        (rf/dispatch [::form-e/set-input-val id path value])))))
 
 (defn on-submit


### PR DESCRIPTION
`on-change` helper function will set value as a number if the input type is `number`.